### PR TITLE
fix: keyword arguments for plugin load

### DIFF
--- a/plugin/manager.py
+++ b/plugin/manager.py
@@ -270,7 +270,7 @@ class PluginManager(PluginLifecycleNotifierMixin, Generic[P]):
             self._fire_on_load_before(plugin_spec, plugin, args, kwargs)
             try:
                 LOG.debug("loading plugin %s:%s", self.namespace, plugin_spec.name)
-                result = plugin.load(*args, *kwargs)
+                result = plugin.load(*args, **kwargs)
                 self._fire_on_load_after(plugin_spec, plugin, result)
                 container.load_value = result
                 container.is_loaded = True

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -111,11 +111,14 @@ class TestPluginManager:
             ]
         )
 
-        manager: PluginManager[DummyPlugin] = PluginManager("test.plugins.dummy", finder=finder)
+        manager: PluginManager[DummyPlugin] = PluginManager(
+            "test.plugins.dummy", finder=finder, load_kwargs={"foo": "bar"}
+        )
 
         plugins = manager.load_all()
         assert len(plugins[0].load_calls) == 1
         assert len(plugins[1].load_calls) == 1
+        assert plugins[0].load_calls[0][1] == {"foo": "bar"}
 
         plugins = manager.load_all()
         assert len(plugins[0].load_calls) == 1


### PR DESCRIPTION
This PR fixes the a small typo preventing the correct usage of arbitrary keyword arguments when loading a plugin.
It slightly adapt a test to simply check that the arguments are received correctly.