### PR TITLE
add metadata package to resolve distribution information

### DIFF
--- a/plugin/manager.py
+++ b/plugin/manager.py
@@ -11,6 +11,7 @@ from .core import (
     PluginSpec,
     PluginSpecResolver,
 )
+from .metadata import resolve_distribution_information
 
 LOG = logging.getLogger(__name__)
 
@@ -113,6 +114,15 @@ class PluginContainer(Generic[P]):
 
     init_error: Exception = None
     load_error: Exception = None
+
+    @property
+    def distribution(self):
+        """
+        Uses metadata from importlib to resolve the distribution information for this plugin.
+
+        :return: the importlib.metadata.Distribution object
+        """
+        return resolve_distribution_information(self.plugin_spec)
 
 
 class PluginManager(PluginLifecycleNotifierMixin, Generic[P]):

--- a/plugin/metadata.py
+++ b/plugin/metadata.py
@@ -1,0 +1,37 @@
+import inspect
+from functools import lru_cache
+from importlib import metadata
+from typing import Mapping, Optional
+
+from .core import PluginSpec
+
+
+@lru_cache()
+def packages_distributions() -> Mapping[str, list[str]]:
+    """
+    Cache wrapper around metadata.packages_distributions, which returns a mapping of top-level packages to
+    their distributions.
+
+    :return: package to distribution mapping
+    """
+    return metadata.packages_distributions()
+
+
+def resolve_distribution_information(plugin_spec: PluginSpec) -> Optional[metadata.Distribution]:
+    """
+    Resolves for a PluginSpec the python distribution package it comes from. Currently, this raises an
+    error for plugins that come from a namespace package (i.e., when a package is part of multiple
+    distributions).
+
+    :param plugin_spec: the plugin spec to resolve
+    :return: the Distribution metadata if it exists
+    """
+    package = inspect.getmodule(plugin_spec.factory).__name__
+    root_package = package.split(".")[0]
+    distributions = packages_distributions().get(root_package)
+    if not distributions:
+        return None
+    if len(distributions) > 1:
+        raise ValueError("cannot deal with plugins that are part of namespace packages")
+
+    return metadata.distribution(distributions[0])

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,0 +1,12 @@
+from plugin import PluginSpec
+from plugin.metadata import resolve_distribution_information
+
+
+def test_resolve_distribution_information():
+    import pytest
+
+    # fake a plugin spec and use pytest as test object
+    fake_plugin_spec = PluginSpec("foo", "bar", pytest.fixture)
+    dist = resolve_distribution_information(fake_plugin_spec)
+    assert dist.name == "pytest"
+    assert dist.metadata["License"] == "MIT"


### PR DESCRIPTION
This PR adds support for fetching `importlib.metadata.Distribution` objects from a `PluginSpec`. This allows you to resolve the python package distribution metadata for a particular plugin, i.e., the pypi package the plugin came from.

We need this for localstack extensions to resolve the distribution name from an extension name.