### PR TITLE
remove pytest-runner from setup_requires

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,6 @@ classifiers =
 zip_safe = False
 packages = find:
 setup_requires =
-    pytest-runner
 	setuptools
 	wheel
 install_requires =


### PR DESCRIPTION
I'm working on this package in [nixpkgs](https://github.com/NixOS/nixpkgs) and would like to not include pytest-runner as a dependency. I think it isn't necessary for setup.py to build the package.