### PR TITLE
add python 3.12 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
+        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11", "3.12" ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/plugin/setuptools.py
+++ b/plugin/setuptools.py
@@ -1,8 +1,6 @@
 import json
 import os
 import sys
-from distutils.command.install_egg_info import safe_name, to_filename
-from distutils.core import Command
 from typing import Optional, Tuple
 
 import pkg_resources
@@ -12,7 +10,7 @@ from setuptools.command.egg_info import InfoCommon, write_entries
 from .entrypoint import EntryPointDict, find_plugins
 
 
-class plugins(InfoCommon, Command):
+class plugins(InfoCommon, setuptools.Command):
     description = "Discover plux plugins and store them in .egg_info"
 
     user_options = [
@@ -59,7 +57,9 @@ def load_plux_entrypoints(cmd, file_name, file_path):
 def get_plux_json_path(distribution):
     dirs = distribution.package_dir
     egg_base = (dirs or {}).get("", os.curdir)
-    egg_info_dir = to_filename(safe_name(distribution.get_name())) + ".egg-info"
+    egg_info_dir = (
+        pkg_resources.to_filename(pkg_resources.safe_name(distribution.get_name())) + ".egg-info"
+    )
     egg_info_dir = os.path.join(egg_base, egg_info_dir)
     return os.path.join(egg_info_dir, "plux.json")
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ test_requires =
 
 [options.extras_require]
 dev =
+    setuptools
     pytest==6.2.4
     black==22.3.0
     isort==5.9.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,9 +29,9 @@ setup_requires =
 	setuptools
 	wheel
 install_requires =
-    setuptools
     stevedore>=3.4
 test_requires =
+    setuptools
     pytest==6.2.4
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,10 +13,12 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Topic :: Software Development :: Libraries
     Topic :: Utilities
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ setup_requires =
 	setuptools
 	wheel
 install_requires =
+    setuptools
     stevedore>=3.4
 test_requires =
     pytest==6.2.4


### PR DESCRIPTION
Various changes to make plux 3.12 compatible.

* add setuptools to dev dependencies (needed by the CLI)
* vendor two pkg_resources utils functions and remove it as dependency
* replace `distutils` imports with appropriate `setuptools` imports
* use `metadata.Distribution` to correctly resolve entry_points.txt

This PR also shows that a lot of modernization and cleanup is needed to better separate build tools (setuptools) from runtime tools (metadata&importlib), and use the current APIs correctly.
