### PR TITLE
drop python 3.7 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/plugin/metadata.py
+++ b/plugin/metadata.py
@@ -2,14 +2,8 @@ import collections
 import inspect
 import sys
 from functools import lru_cache
+from importlib import metadata
 from typing import List, Mapping, Optional
-
-try:
-    from importlib import metadata
-except ImportError:
-    import importlib_metadata as metadata
-
-from .core import PluginSpec
 
 if sys.version_info >= (3, 10):
     from importlib.metadata import packages_distributions as metadata_packages_distributions
@@ -23,6 +17,8 @@ else:
                 pkg_to_dist[pkg].append(dist.metadata["Name"])
         return dict(pkg_to_dist)
 
+
+from .core import PluginSpec
 
 Distribution = metadata.Distribution
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -23,6 +22,7 @@ classifiers =
     Topic :: Utilities
 
 [options]
+python_requires = >=3.8
 zip_safe = False
 packages = find:
 setup_requires =


### PR DESCRIPTION
Python 3.7 has been unsupported since 2023-06-27, and has started making troubles in #14, so it's a good time to drop support for it.