### PR TITLE
allow lifecycle listeners to disabled plugins using PluginDisabled exceptions

### DIFF
--- a/plux/__init__.py
+++ b/plux/__init__.py
@@ -27,6 +27,7 @@ __all__ = [
     "PluginFactory",
     "PluginFinder",
     "PluginLifecycleListener",
+    "CompositePluginLifecycleListener",
     "PluginManager",
     "PluginContainer",
     "PluginSpec",

--- a/plux/core/plugin.py
+++ b/plux/core/plugin.py
@@ -12,6 +12,8 @@ class PluginException(Exception):
 
 
 class PluginDisabled(PluginException):
+    reason: str
+
     def __init__(self, namespace: str, name: str, reason: str = None):
         message = f"plugin {namespace}:{name} is disabled"
         if reason:
@@ -19,6 +21,7 @@ class PluginDisabled(PluginException):
         super(PluginDisabled, self).__init__(message)
         self.namespace = namespace
         self.name = name
+        self.reason = reason
 
 
 class Plugin(abc.ABC):

--- a/tests/plugins/sample_plugins.py
+++ b/tests/plugins/sample_plugins.py
@@ -32,3 +32,17 @@ def plugin_3():
 @plugin(name="plugin_4", namespace="namespace_3")
 def functional_plugin():
     return "another"
+
+
+def load_condition():
+    return False
+
+
+@plugin(name="plugin_5", namespace="namespace_4", should_load=lambda: load_condition())
+def functional_plugin_with_load_condition_function():
+    return "not loading this one"
+
+
+@plugin(name="plugin_6", namespace="namespace_4", should_load=False)
+def functional_plugin_with_load_condition_bool():
+    return "not loading this one either"

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -10,7 +10,7 @@ class TestModuleScanningPluginFinder:
         finder = ModuleScanningPluginFinder(modules=[sample_plugins])
 
         plugins = finder.find_plugins()
-        assert len(plugins) == 5
+        assert len(plugins) == 7
 
         plugins = [(spec.namespace, spec.name) for spec in plugins]
 
@@ -20,6 +20,8 @@ class TestModuleScanningPluginFinder:
         assert ("namespace_1", "plugin_2") in plugins
         assert ("namespace_3", "plugin_3") in plugins
         assert ("namespace_3", "plugin_4") in plugins
+        assert ("namespace_4", "plugin_5") in plugins
+        assert ("namespace_4", "plugin_6") in plugins
 
 
 class TestPackagePathPluginFinder:
@@ -29,7 +31,7 @@ class TestPackagePathPluginFinder:
         finder = PackagePathPluginFinder(where=where, include=("tests.plugins",))
 
         plugins = finder.find_plugins()
-        assert len(plugins) == 5
+        assert len(plugins) == 7
 
         plugins = [(spec.namespace, spec.name) for spec in plugins]
 
@@ -39,3 +41,5 @@ class TestPackagePathPluginFinder:
         assert ("namespace_1", "plugin_2") in plugins
         assert ("namespace_3", "plugin_3") in plugins
         assert ("namespace_3", "plugin_4") in plugins
+        assert ("namespace_4", "plugin_5") in plugins
+        assert ("namespace_4", "plugin_6") in plugins

--- a/tests/test_function_plugin.py
+++ b/tests/test_function_plugin.py
@@ -1,4 +1,8 @@
+import pytest
+
 from plugin import PluginManager
+from plux import PluginDisabled
+from tests.plugins import sample_plugins
 
 
 def test_load_functional_plugins(sample_plugin_finder):
@@ -20,3 +24,33 @@ def test_load_functional_plugins(sample_plugin_finder):
     # function plugins are callable directly
     assert plugin_3() == "foobar"
     assert plugin_4() == "another"
+
+
+def test_load_functional_plugins_with_load_condition_false(sample_plugin_finder):
+    manager = PluginManager("namespace_4", finder=sample_plugin_finder)
+
+    plugins = manager.load_all()
+    assert len(plugins) == 0
+
+    with pytest.raises(PluginDisabled) as e:
+        manager.load("plugin_5")
+    e.match("plugin namespace_4:plugin_5 is disabled, reason: Load condition for plugin was false")
+
+    with pytest.raises(PluginDisabled) as e:
+        manager.load("plugin_6")
+    e.match("plugin namespace_4:plugin_6 is disabled, reason: Load condition for plugin was false")
+
+
+def test_load_functional_plugins_with_load_condition_patchd(sample_plugin_finder, monkeypatch):
+    monkeypatch.setattr(sample_plugins, "load_condition", lambda: True)
+
+    manager = PluginManager("namespace_4", finder=sample_plugin_finder)
+
+    plugins = manager.load_all()
+    assert len(plugins) == 1
+
+    manager.load("plugin_5")
+
+    with pytest.raises(PluginDisabled) as e:
+        manager.load("plugin_6")
+    e.match("plugin namespace_4:plugin_6 is disabled, reason: Load condition for plugin was false")

--- a/tests/test_listener.py
+++ b/tests/test_listener.py
@@ -1,0 +1,149 @@
+import typing as t
+from typing import Dict, List, Tuple
+from unittest.mock import MagicMock
+
+import pytest
+
+from plux import (
+    CompositePluginLifecycleListener,
+    Plugin,
+    PluginDisabled,
+    PluginException,
+    PluginFinder,
+    PluginLifecycleListener,
+    PluginManager,
+    PluginSpec,
+)
+
+
+class DummyPlugin(Plugin):
+    load_calls: List[Tuple[Tuple, Dict]]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.load_calls = list()
+
+    def load(self, *args, **kwargs):
+        self.load_calls.append((args, kwargs))
+
+
+class ShouldNotLoadPlugin(DummyPlugin):
+    def should_load(self) -> bool:
+        return False
+
+
+class GoodPlugin(DummyPlugin):
+    pass
+
+
+class _DummyPluginFinder(PluginFinder):
+    def __init__(self, specs: List[PluginSpec]):
+        self.specs = specs
+
+    def find_plugins(self) -> List[PluginSpec]:
+        return self.specs
+
+
+@pytest.fixture
+def dummy_plugin_finder():
+    return _DummyPluginFinder(
+        [
+            PluginSpec("test.plugins.dummy", "plugin1", GoodPlugin),
+            PluginSpec("test.plugins.dummy", "plugin2", GoodPlugin),
+        ]
+    )
+
+
+class TestListener:
+    def test_listeners_called(self, dummy_plugin_finder):
+        listener = MagicMock()
+        listener.on_resolve_after = MagicMock()
+        listener.on_init_exception = MagicMock()
+        listener.on_init_after = MagicMock()
+        listener.on_load_before = MagicMock()
+        listener.on_load_after = MagicMock()
+        listener.on_load_exception = MagicMock()
+
+        manager = PluginManager(
+            "test.plugins.dummy",
+            finder=dummy_plugin_finder,
+            listener=CompositePluginLifecycleListener([listener]),
+        )
+
+        plugins = manager.load_all()
+        assert len(plugins) == 2
+
+        assert listener.on_resolve_after.call_count == 2
+        assert listener.on_init_exception.call_count == 0
+        assert listener.on_init_after.call_count == 2
+        assert listener.on_load_before.call_count == 2
+        assert listener.on_load_after.call_count == 2
+        assert listener.on_load_exception.call_count == 0
+
+    def test_on_init_after_can_disable_plugin(self, dummy_plugin_finder):
+        class _DisableListener(PluginLifecycleListener):
+            def on_init_after(self, plugin_spec: PluginSpec, plugin: Plugin):
+                if plugin_spec.name == "plugin2":
+                    raise PluginDisabled(
+                        plugin_spec.namespace, plugin_spec.name, "decided during init"
+                    )
+
+        manager = PluginManager(
+            "test.plugins.dummy",
+            finder=dummy_plugin_finder,
+            listener=_DisableListener(),
+        )
+
+        plugins = manager.load_all()
+        assert len(plugins) == 1
+
+        with pytest.raises(PluginDisabled) as e:
+            manager.load("plugin2")
+
+        assert e.match("decided during init")
+
+    def test_on_load_before_can_disable_plugin(self, dummy_plugin_finder):
+        class _DisableListener(PluginLifecycleListener):
+            def on_load_before(
+                self, plugin_spec: PluginSpec, _plugin: Plugin, _load_args, _load_kwargs
+            ):
+                if plugin_spec.name == "plugin2":
+                    raise PluginDisabled(
+                        plugin_spec.namespace, plugin_spec.name, "decided during load"
+                    )
+
+        manager = PluginManager(
+            "test.plugins.dummy",
+            finder=dummy_plugin_finder,
+            listener=_DisableListener(),
+        )
+
+        plugins = manager.load_all()
+        assert len(plugins) == 1
+
+        with pytest.raises(PluginDisabled) as e:
+            manager.load("plugin2")
+
+        assert e.match("decided during load")
+
+    def test_on_after_before_with_error(self, dummy_plugin_finder):
+        class _DisableListener(PluginLifecycleListener):
+            def on_load_after(
+                self, plugin_spec: PluginSpec, plugin: Plugin, load_result: t.Any = None
+            ):
+                if plugin_spec.name == "plugin2":
+                    raise PluginException("error loading plugin 2")
+
+        manager = PluginManager(
+            "test.plugins.dummy",
+            finder=dummy_plugin_finder,
+            listener=_DisableListener(),
+        )
+
+        plugins = manager.load_all()
+        assert len(plugins) == 1
+
+        with pytest.raises(PluginException) as e:
+            manager.load("plugin2")
+
+        assert e.match("error loading plugin 2")


### PR DESCRIPTION
## Motivation

While developing a localstack platform plugin, @simonrw noticed that the platform plugins weren't disabled correctly, even though they should have been. The reason was that the `PluginDisabled` exception raised by one of the listeners acting as a loader guard was not handled correctly in plux. Plugins were loaded normally even though the listener raised an exception.

This PR changes how exceptions from `PluginLifecycleListener`s are handled. Specifically, we re-raise `PluginException` through to the plugin manager. Additionally, we introduce an `is_disabled` flag into the `PluginContainer`, which allow the plugin manager to raise an appropriate `PluginDisabled` exception on repeated calls of `load`.

Added a few tests as well.

## Changes
* `PluginDisabled` now holds the reason correctly
* `PluginException` (which includes `PluginDisabled` are now propagated through the `_call_safe` method, therefore allowing listeners to influence the `_load_plugin` routine.
* `CompositePluginLifecycleListener` is now correctly exported through the `plux` module (minor drive-by fix)