### PR TITLE
add global filter to disable plugins based on pattern matching

### DIFF
--- a/plux/runtime/filter.py
+++ b/plux/runtime/filter.py
@@ -47,7 +47,7 @@ class PluginSpecMatcher:
 
 
 class MatchingPluginFilter:
-    matchers: list[PluginSpecMatcher]
+    matchers: t.List[PluginSpecMatcher]
 
     def __init__(self):
         self.matchers = []

--- a/plux/runtime/filter.py
+++ b/plux/runtime/filter.py
@@ -1,0 +1,83 @@
+import fnmatch
+import logging
+import typing as t
+
+from plux.core.entrypoint import spec_to_entry_point
+from plux.core.plugin import PluginSpec
+
+LOG = logging.getLogger(__name__)
+
+
+class PluginFilter(t.Protocol):
+    def __call__(self, spec: PluginSpec) -> bool:
+        """
+        Returns True if the plugin should be filtered (disabled), or False otherwise.
+
+        :param spec: the spec to check
+        :return: True if the plugin should be disabled
+        """
+        ...
+
+
+class PluginSpecMatcher:
+    namespace: str = None
+    name: str = None
+    value: str = None
+
+    def __init__(self, namespace: str = None, name: str = None, value: str = None):
+        self.namespace = namespace
+        self.name = name
+        self.value = value
+
+    def matches(self, spec: PluginSpec) -> bool:
+        if self.namespace:
+            if not fnmatch.fnmatch(spec.namespace, self.namespace):
+                return False
+
+        if self.name:
+            if not fnmatch.fnmatch(spec.name, self.name):
+                return False
+
+        if self.value:
+            ep = spec_to_entry_point(spec)
+            if not fnmatch.fnmatch(ep.value, self.value):
+                return False
+
+        return True
+
+
+class MatchingPluginFilter:
+    matchers: list[PluginSpecMatcher]
+
+    def __init__(self):
+        self.matchers = []
+
+    def add_pattern(self, namespace: str = None, name: str = None, value: str = None):
+        """
+        Adds a pattern of plugins that should be excluded. The patterns use ``fnmatch``. For example::
+
+            # filters all plugins with a namespace "some.namespace.a", "some.namespace.b", ...
+            add_pattern(namespace = "some.namespace.*")
+
+            # filters all plugins that come from a specific package tree
+            add_pattern(value = "my.package.*")
+
+        Combining parameters will create an `AND` clause.
+
+        :param namespace:
+        :param name:
+        :param value:
+        :return:
+        """
+        self.matchers.append(PluginSpecMatcher(namespace=namespace, name=name, value=value))
+
+    def __call__(self, spec: PluginSpec) -> bool:
+        for matcher in self.matchers:
+            if matcher.matches(spec):
+                # do not load the plugin if it matches the spec
+                LOG.debug("Filter rule %s matched %s", matcher, spec)
+                return True
+        return False
+
+
+global_plugin_filter = MatchingPluginFilter()

--- a/plux/runtime/filter.py
+++ b/plux/runtime/filter.py
@@ -24,7 +24,7 @@ class PluginSpecMatcher:
     name: str = None
     value: str = None
 
-    def __init__(self, namespace: str = None, name: str = None, value: str = None):
+    def __init__(self, *, namespace: str = None, name: str = None, value: str = None):
         self.namespace = namespace
         self.name = name
         self.value = value
@@ -45,22 +45,29 @@ class PluginSpecMatcher:
 
         return True
 
+    def __str__(self):
+        return f"PluginSpecMatcher({self.__dict__})"
+
 
 class MatchingPluginFilter:
-    matchers: t.List[PluginSpecMatcher]
+    """
+    A MatchingPluginFilter can be used to exclude specific plugins from loading.
+    """
+
+    exclusions: t.List[PluginSpecMatcher]
 
     def __init__(self):
-        self.matchers = []
+        self.exclusions = []
 
-    def add_pattern(self, namespace: str = None, name: str = None, value: str = None):
+    def add_exclusion(self, *, namespace: str = None, name: str = None, value: str = None):
         """
         Adds a pattern of plugins that should be excluded. The patterns use ``fnmatch``. For example::
 
             # filters all plugins with a namespace "some.namespace.a", "some.namespace.b", ...
-            add_pattern(namespace = "some.namespace.*")
+            add_exclusion(namespace = "some.namespace.*")
 
             # filters all plugins that come from a specific package tree
-            add_pattern(value = "my.package.*")
+            add_exclusion(value = "my.package.*")
 
         Combining parameters will create an `AND` clause.
 
@@ -69,10 +76,17 @@ class MatchingPluginFilter:
         :param value:
         :return:
         """
-        self.matchers.append(PluginSpecMatcher(namespace=namespace, name=name, value=value))
+        self.exclusions.append(PluginSpecMatcher(namespace=namespace, name=name, value=value))
 
     def __call__(self, spec: PluginSpec) -> bool:
-        for matcher in self.matchers:
+        """
+        Checks whether a given ``PluginSpec`` matches the filter criteria. If the matcher returns True,
+        the plugin should be disabled.
+
+        :param spec: the plugin spec
+        :return: True if the plugin should be disabled
+        """
+        for matcher in self.exclusions:
             if matcher.matches(spec):
                 # do not load the plugin if it matches the spec
                 LOG.debug("Filter rule %s matched %s", matcher, spec)

--- a/plux/runtime/manager.py
+++ b/plux/runtime/manager.py
@@ -169,6 +169,18 @@ class PluginManager(PluginLifecycleNotifierMixin, t.Generic[P]):
         finder: PluginFinder = None,
         filters: t.List[PluginFilter] = None,
     ):
+        """
+        Create a new PluginManager.
+
+        :param namespace: the namespace (entry point group) that will be managed
+        :param load_args: positional arguments passed to ``Plugin.load()``
+        :param load_kwargs: keyword arguments passed to ``Plugin.load()``
+        :param listener: plugin lifecycle listeners, can either be a single listener or a list
+        :param finder: the plugin finder to be used, by default it uses a ``MetadataPluginFinder`
+        :param filters: filters exclude specific plugins. when no filters are provided, a list is created
+            and ``global_plugin_filter`` is added to it. filters can later be modified via
+            ``plugin_manager.filters``.
+        """
         self.namespace = namespace
 
         self.load_args = load_args or list()

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -199,40 +199,40 @@ class TestGlobalPluginFilter:
     def test_disable_namespace(self, dummy_plugin_finder):
         manager = PluginManager("test.plugins.dummy", finder=dummy_plugin_finder)
 
-        global_plugin_filter.add_pattern("test.plugins.*")
+        global_plugin_filter.add_exclusion(namespace="test.plugins.*")
 
         manager.load_all()
         assert manager.is_loaded("shouldload") is False
         assert manager.is_loaded("shouldalsoload") is False
 
-        global_plugin_filter.matchers.clear()
+        global_plugin_filter.exclusions.clear()
 
     def test_non_matching_namespace(self, dummy_plugin_finder):
         manager = PluginManager("test.plugins.dummy", finder=dummy_plugin_finder)
 
-        global_plugin_filter.add_pattern("test.plugins.dummy.*")
+        global_plugin_filter.add_exclusion(namespace="test.plugins.dummy.*")
 
         manager.load_all()
         assert manager.is_loaded("shouldload") is True
         assert manager.is_loaded("shouldalsoload") is True
-        global_plugin_filter.matchers.clear()
+        global_plugin_filter.exclusions.clear()
 
     def test_disable_name(self, dummy_plugin_finder):
         manager = PluginManager("test.plugins.dummy", finder=dummy_plugin_finder)
 
-        global_plugin_filter.add_pattern(name="*also*")
+        global_plugin_filter.add_exclusion(name="*also*")
 
         manager.load_all()
         assert manager.is_loaded("shouldload") is True
         assert manager.is_loaded("shouldalsoload") is False
-        global_plugin_filter.matchers.clear()
+        global_plugin_filter.exclusions.clear()
 
     def test_disable_value(self, dummy_plugin_finder):
         manager = PluginManager("test.plugins.dummy", finder=dummy_plugin_finder)
 
-        global_plugin_filter.add_pattern(value="tests.test_manager:*")
+        global_plugin_filter.add_exclusion(value="tests.test_manager:*")
 
         manager.load_all()
         assert manager.is_loaded("shouldload") is False
         assert manager.is_loaded("shouldalsoload") is False
-        global_plugin_filter.matchers.clear()
+        global_plugin_filter.exclusions.clear()

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from plugin import Plugin, PluginDisabled, PluginFinder, PluginManager, PluginSpec
+from plux.runtime.filter import global_plugin_filter
 
 
 class DummyPlugin(Plugin):
@@ -192,3 +193,46 @@ class TestPluginManager:
 
         container = manager.get_container("shouldalsoload")
         listener.on_load_after.assert_called_with(container.plugin_spec, container.plugin, None)
+
+
+class TestGlobalPluginFilter:
+    def test_disable_namespace(self, dummy_plugin_finder):
+        manager = PluginManager("test.plugins.dummy", finder=dummy_plugin_finder)
+
+        global_plugin_filter.add_pattern("test.plugins.*")
+
+        manager.load_all()
+        assert manager.is_loaded("shouldload") is False
+        assert manager.is_loaded("shouldalsoload") is False
+
+        global_plugin_filter.matchers.clear()
+
+    def test_non_matching_namespace(self, dummy_plugin_finder):
+        manager = PluginManager("test.plugins.dummy", finder=dummy_plugin_finder)
+
+        global_plugin_filter.add_pattern("test.plugins.dummy.*")
+
+        manager.load_all()
+        assert manager.is_loaded("shouldload") is True
+        assert manager.is_loaded("shouldalsoload") is True
+        global_plugin_filter.matchers.clear()
+
+    def test_disable_name(self, dummy_plugin_finder):
+        manager = PluginManager("test.plugins.dummy", finder=dummy_plugin_finder)
+
+        global_plugin_filter.add_pattern(name="*also*")
+
+        manager.load_all()
+        assert manager.is_loaded("shouldload") is True
+        assert manager.is_loaded("shouldalsoload") is False
+        global_plugin_filter.matchers.clear()
+
+    def test_disable_value(self, dummy_plugin_finder):
+        manager = PluginManager("test.plugins.dummy", finder=dummy_plugin_finder)
+
+        global_plugin_filter.add_pattern(value="tests.test_manager:*")
+
+        manager.load_all()
+        assert manager.is_loaded("shouldload") is False
+        assert manager.is_loaded("shouldalsoload") is False
+        global_plugin_filter.matchers.clear()


### PR DESCRIPTION
## Motivation

Sometimes we want to re-use code that injects plugins we _don't_ want to use. To facilitate this, I added a way to filter plugins based on simple fnmatch rules. You can disable plugins by namespaces, names, or even values.

Here are some examples of how it can be used:
```python
from plux.runtime.filter import global_plugin_filter

# disables all plugins in the `localstack.aws.provider` namespace
global_plugin_filter.add_pattern(namespace = "localstack.aws.provider")

# disables all plugins in namespaces that start with `localstack.aws.`
global_plugin_filter.add_pattern(namespace = "localstack.aws.*")

# disables all plugins that come from the `localstack.services` package, regardless in which namespace
global_plugin_filter.add_pattern(value = "localstack.services.*")

# disables all plugins that come from the `localstack.services` package, but only if they are in the `localstack.aws.provider` namespace
global_plugin_filter.add_pattern(namespace = "localstack.aws.provider", value = "localstack.services.*")

# disables any plugin named "iam-enforcement"
global_plugin_filter.add_pattern(name = "iam-enforcement")
```

## Changes

* a global filter is added by default to every `PluginManager`, that does nothing unless configured otherwise