### PR TITLE
fix duplication issue in packages_distributions

### DIFF
--- a/plux/__init__.py
+++ b/plux/__init__.py
@@ -17,7 +17,7 @@ from plux.runtime.manager import PluginContainer, PluginManager
 
 name = "plux"
 
-__version__ = "1.11.0"
+__version__ = "1.11.1"
 
 __all__ = [
     "FunctionPlugin",


### PR DESCRIPTION
This PR fixes an issue that @Pive01 raised, where localstack's `/_localstack/extension/list` endpoint would fail to list extensions installed in developer mode. I pinned it down to this root cause that `resolve_distribution_information` would raise a `ValueError`, because `localstack-extension-hello-world` (for example) would appear twice in `packages_distributions().get("helloworld")`.

As explained in the code doc i added:
With editable installs, `packages_distributions()` may return the distribution metadata for both the `.egg-info` in the linked source directory, and the `.dist-info` in the site-packages directory created by the editable install. Therefore, a distribution name may appear twice for the same package. Subsequently raising a ValueError.