### PR TITLE
fix entrypoints installation by limiting setuptools compatiblity

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ setup_requires =
 	wheel
 install_requires =
     importlib-metadata>=0.12;python_version<"3.8"
+    setuptools<=75.1.0
 test_requires =
     setuptools
     pytest==6.2.4


### PR DESCRIPTION
## Motivation
With `setuptools==75.2.0`, `plux` has issues when restoring the entrypoints on the installation of source distributions.
This is caused by https://github.com/pypa/setuptools/pull/4647, it might be specifically relate to [this comment](https://github.com/pypa/setuptools/pull/4647/files#r1760120230). It definitely is caused by the fact that the `egg_info` command and the `egg2dist` is not called anymore.

I also tried to dive into this with a hack implemented in  https://github.com/localstack/plux/commit/ffb1ad9d086a5ebd72d69f462cf201dd5499d475 which will be taken over by @thrau.

In LocalStack, we are mitigating this issue by introducing a limit in the `build-system.requires`: https://github.com/localstack/localstack/pull/11715

However, this only fixes the issue in upcoming releases, the source distributions out there won't be affected by this change.
This is why plux itself should declare that it is not compatible with the latest release of `setuptools`.

## Changes
This PR introduces `setuptools` as an install dependency (which it is and always was) and limits the version to `<=75.1.0` (which is the latest compatible version).
This change can be reverted as soon as `plux` is compatible with the latest version of `setuptools` again.

## Testing
I verified that this fix by executing the following steps / scripts:
- Use the local version of plux in one of the test projects:
  ```diff
  diff --git a/tests/cli/projects/pyproject/pyproject.toml b/tests/cli/projects/pyproject/pyproject.toml
  index 54c5728..9f69017 100644
  --- a/tests/cli/projects/pyproject/pyproject.toml
  +++ b/tests/cli/projects/pyproject/pyproject.toml
  @@ -1,5 +1,5 @@
   [build-system]
  -requires = ["setuptools", "wheel", "plux"]
  +requires = ["setuptools", "wheel", "plux@file:///home/localstack/Repos/plux"]
   build-backend = "setuptools.build_meta"
   
   [project]
  ```
- Apply the change in this PR
- Run the following script to verify that the entrypoints are correctly available after installing the source distribution:
  ```bash
  #!/bin/bash
  set -e
  
  # make sure setuptools on the system and in the venv is up to date.
  pip install --upgrade setuptools
  
  # create a test-venv and also ugprade setuptools
  cd tests/cli/projects/pyproject/
  rm -rf setuptools-test-venv
  python3 -m venv setuptools-test-venv
  source setuptools-test-venv/bin/activate
  pip install --upgrade setuptools
  
  # build the project
  rm -rf dist
  pip install build
  python3 -m build
  
  # install the source distribution with the local plux reference
  pip install --no-cache dist/test_project-0.1.0.tar.gz
  
  # check if the entryponts have been created / print the output:
  cat setuptools-test-venv/lib/python3.11/site-packages/test_project-0.1.0.dist-info/entry_points.txt
  ```
  The path in the last line might need to be adjusted based on the Python version.