### PR TITLE
add egg_info command patch to fix pip building with setuptools==75.2.0

### DIFF
--- a/plux/build/setuptools.py
+++ b/plux/build/setuptools.py
@@ -136,7 +136,7 @@ def patch_egg_info_command():
             LOG.debug("Locating plux.json from local build context %s", meta_dir)
             plux_json = os.path.join(meta_dir, "plux.json")
             if os.path.exists(plux_json):
-                self.mkpath(self.egg_info)  # this is what egg_info.run()
+                self.mkpath(self.egg_info)  # this is what egg_info.run() does but it's idempotent
                 if not os.path.exists(os.path.join(self.egg_info, "plux.json")):
                     LOG.debug("copying %s into temporary %s", plux_json, self.egg_info)
                     shutil.copy(plux_json, self.egg_info)

--- a/plux/build/setuptools.py
+++ b/plux/build/setuptools.py
@@ -6,11 +6,13 @@ import json
 import logging
 import os
 import re
+import shutil
 import sys
 import typing as t
 from pathlib import Path
 
 import setuptools
+from setuptools.command.egg_info import egg_info
 
 try:
     from setuptools.command.editable_wheel import editable_wheel
@@ -105,6 +107,46 @@ def patch_editable_wheel_command():
 
 # patch will be applied implicitly through the entry point that loads the ``plugins`` command.
 patch_editable_wheel_command()
+
+
+def patch_egg_info_command():
+    """
+    This patch fixes the build process when pip builds a wheel from a source distribution. A source distribution built
+    with plux will already contain an `.egg_info` directory, however during the build with pip, a new .egg-info
+    directory is created from scratch from the python distribution configuration files (like setup.cfg or
+    pyproject.toml). This is a problem, as building a wheel involves creating a .dist-info dir, which is populated from
+    this new .egg-info directory. The .egg-info shipped with the source distribution is completely ignored during this
+    process, including the `plux.json`, leading to a wheel that does not correctly contain the `entry_points.txt`.
+
+    This patch hooks into this procedure, and makes sure when this new .egg-info directory is created, we first locate
+    the one shipped with the source distribution, locate the `plux.json` file, and copy it into the new build context.
+    """
+    _run_orig = egg_info.run
+
+    def _run(self):
+        LOG.debug("Running egg_info command patch from plux")
+        # the working directory may be something like `/tmp/pip-req-build-bwekzpi_` where the source distribution
+        # was copied into. this happens when you `pip install <dist>` where <dist> is
+        # some source distribution.
+        should_read, meta_dir = _should_read_existing_egg_info()
+
+        # if the .egg_info from the source distribution contains the plux file, we prepare the new .egg-info by copying
+        # it there. everything else should be handled implicitly by the command
+        if should_read:
+            LOG.debug("Locating plux.json from local build context %s", meta_dir)
+            plux_json = os.path.join(meta_dir, "plux.json")
+            if os.path.exists(plux_json):
+                self.mkpath(self.egg_info)  # this is what egg_info.run()
+                if not os.path.exists(os.path.join(self.egg_info, "plux.json")):
+                    LOG.debug("copying %s into temporary %s", plux_json, self.egg_info)
+                    shutil.copy(plux_json, self.egg_info)
+
+        return _run_orig(self)
+
+    egg_info.run = _run
+
+
+patch_egg_info_command()
 
 
 def find_plugins(where=".", exclude=(), include=("*",)) -> EntryPointDict:
@@ -252,7 +294,11 @@ def _is_local_build_context():
         try:
             i = sys.argv.index("--egg-base")
         except ValueError:
-            return False
+            try:
+                # this code path is for building wheels from source distributions via pip
+                i = sys.argv.index("--output-dir")
+            except ValueError:
+                return False
 
         if "pip-modern-metadata" in sys.argv[i + 1]:
             return True

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,6 @@ setup_requires =
 	wheel
 install_requires =
     importlib-metadata>=0.12;python_version<"3.8"
-    setuptools<=75.1.0
 test_requires =
     setuptools
     pytest==6.2.4


### PR DESCRIPTION
## Motivation
This PR addresses an issue that surfaced with setuptools 75.2.0, most likely this PR: https://github.com/pypa/setuptools/pull/4647

When you `pip install <some-source-distribution>`, the following things happen (among others):
* pip extracts the source distribution `.tar.gz` into some temporary folder, say `/tmp/pip-req-build-bwekzpi_`, this directory will contain the `.egg-info` that was packaged with the source distribution
* pip creates a new temporary directory where the "modern metadata" will land (i.e., `.dist-info` directory)
* pip calls a `prepare_metadata_for_build_wheel` on the build backend
* setuptools `prepare_metadata_for_build_wheel` is just a wrapper around the `dist_info` command, which again first calls the `egg_info` command
* setuptools populates the `.dist-info` directory from the newly created `.egg-info` directory (which are both in pip's temporary build context)

Here's a an example where I run `pip install /path/to/test-library/dist/test_library-0.1.0.tar.gz`:
![pip-build-context](https://github.com/user-attachments/assets/ef33aa58-31f6-4c33-8ef8-b10f501d5686)

The issue is that this temporary `.egg-info` directory is completely built from scratch from the python configuration files (pyproject.toml or setup.cfg). no previously generated metadata files from the original source distribution are copied. 

This PR adds a patch to `egg_info` to address this issue. when plux is part of the setup procedure, it detects a local pip build context and copies the `plux.json` file from the extracted source distribution into the temporary build context. the remaining `egg_info` command proceeds normally and will then create the `entry_points.txt` correctly through the `plux.json` [egg-info writer plugin](https://github.com/localstack/plux/blob/6f19be768efaea4670a69d836e0ea520a8655983/setup.cfg#L55-L57).

## Changes

* plux copies the `plux.json` file from the original source distribution into the temporary build context when building with pip 