### PR TITLE
fix issue with absolute paths landing in SOURCE.txt

### DIFF
--- a/plux/build/setuptools.py
+++ b/plux/build/setuptools.py
@@ -345,12 +345,16 @@ def get_distribution_from_workdir(workdir: str) -> setuptools.Distribution:
 
     dist = setuptools.Distribution()
     dist.parse_config_files(config_files)
-    if os.path.exists("setup.py"):
+    if os.path.exists(os.path.join(workdir, "setup.py")):
         # use setup.py script if available
         dist.script_name = os.path.join(workdir, "setup.py")
     else:
-        # else use a bogus file (seems to work regardless)
+        # else use a config file (seems to work regardless)
         dist.script_name = config_files[0]
+
+    # note: the property Distribution.script_name is added to `SOURCES.txt` during the `sdist` command. the path
+    # must be a relative path. see https://github.com/localstack/plux/issues/23
+    dist.script_name = os.path.relpath(dist.script_name, workdir)
 
     return dist
 

--- a/tests/cli/test_entrypoints.py
+++ b/tests/cli/test_entrypoints.py
@@ -1,5 +1,6 @@
 import os.path
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -26,3 +27,9 @@ def test_entrypoints(project_name):
     with open(os.path.join(project, "test_project.egg-info", "entry_points.txt"), "r") as f:
         lines = [line.strip() for line in f.readlines() if line.strip()]
         assert lines == ["[plux.test.plugins]", "myplugin = mysrc.plugins:MyPlugin"]
+
+    # make sure that SOURCES.txt contain no absolute paths
+    with open(os.path.join(project, "test_project.egg-info", "SOURCES.txt"), "r") as f:
+        lines = [line.strip() for line in f.readlines() if line.strip()]
+        for line in lines:
+            assert not line.startswith("/")


### PR DESCRIPTION
## Motivation

Fixes https://github.com/localstack/plux/issues/23

The property `Distribution.script_name` is added to `SOURCES.txt` during the `sdist` command here: https://github.com/pypa/setuptools/blob/a39336ba37c50695f5a57be20d8452e46a4ceb10/setuptools/_distutils/command/sdist.py#L260

When we set the argument, we set it to an absolute path, therefore the absolute path is also written into the manifest.

 ## Changes

* `dist.script_name` is now set to a relative path value rather than an absolute path when loading `Distribution` instances from their metadata