### PR TITLE
handle PEP 639 License-Expression in test metadata

### DIFF
--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -9,4 +9,6 @@ def test_resolve_distribution_information():
     fake_plugin_spec = PluginSpec("foo", "bar", pytest.fixture)
     dist = resolve_distribution_information(fake_plugin_spec)
     assert dist.metadata["Name"] == "pytest"
-    assert dist.metadata["License"] == "MIT"
+    # Support both legacy License field and PEP 639 License-Expression
+    license_value = dist.metadata.get("License-Expression") or dist.metadata.get("License")
+    assert license_value == "MIT"


### PR DESCRIPTION
## Problem

`test_resolve_distribution_information` asserts `dist.metadata["License"] == "MIT"` against the installed pytest package. This fails when pytest is built with [PEP 639](https://peps.python.org/pep-0639/) metadata (setuptools >= 77), because the `License` header no longer exists — it is replaced by `License-Expression`.

## Why upstream CI doesn't catch it

The dev dependencies pin `pytest==8.4.1`, which was built with older setuptools and still has the legacy `License: MIT` header in its METADATA. The test only fails with pytest >= 9.0, which requires `setuptools>=77` and emits PEP 639 metadata (`License-Expression: MIT` with no `License` field).

Any environment that doesn't use the pinned pytest version (e.g. nixpkgs, conda, other distros) hits this failure.

## Fix

Use `.get()` to check `License-Expression` first, then fall back to `License`. This handles both old-style and PEP 639 metadata:

```python
license_value = dist.metadata.get("License-Expression") or dist.metadata.get("License")
assert license_value == "MIT"
```

Using `.get()` instead of `[]` also avoids the `DeprecationWarning` from `importlib.metadata` about implicit `None` returns on missing keys, which will become a `KeyError` in a future Python version.